### PR TITLE
정상 종료는 에러 로그를 남기지 않도록 수정

### DIFF
--- a/pkg/slack/bot/bot.go
+++ b/pkg/slack/bot/bot.go
@@ -3,9 +3,7 @@ package bot
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"log/slog"
-	"net"
 
 	"github.com/gorilla/websocket"
 
@@ -68,7 +66,7 @@ func receiveEvent(conn *websocket.Conn) chan event.SocketEvent {
 	go func() {
 		_, msg, err := conn.ReadMessage()
 		if err != nil {
-			if !errors.Is(err, net.ErrClosed) {
+			if !websocket.IsCloseError(err, websocket.CloseNormalClosure) {
 				slog.Error("failed to read websocket message", slog.Any("error", err))
 			}
 			close(ch)


### PR DESCRIPTION
정상적으로 소켓 연결이 종료된 경우 에러 로그가 남지 않도록 한다.
