### PR TITLE
릴리즈 워크플로우 추가

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,75 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*.*.*"]
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      version: ${{ steps.export.outputs.version }}
+
+    strategy:
+      matrix:
+        target:
+        - lumos
+        - dense-retrieval
+
+    steps:
+    # https://github.com/actions/checkout
+    - name: Checkout repository
+      uses: actions/checkout@v5
+
+    # https://github.com/docker/setup-buildx-action
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    # https://github.com/docker/login-action
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ vars.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PAT }}
+
+    # https://github.com/docker/metadata-action
+    - name: Extract Docker metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      env:
+        DOCKER_METADATA_SHORT_SHA_LENGTH: 8
+      with:
+        images: ${{ vars.DOCKERHUB_USERNAME }}/${{ matrix.target }}
+        tags: |
+          type=semver,pattern={{version}}
+          type=sha,prefix=commit-,format=short
+
+    # https://github.com/docker/build-push-action
+    - name: Build and push ${{ matrix.target }}
+      id: build-and-push
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ./build/${{ matrix.target }}/Dockerfile
+        tags: ${{ steps.meta.outputs.tags }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        push: true
+
+    - name: Export version
+      id: export
+      run: echo "version=${{ steps.meta.outputs.version }}" >> "$GITHUB_OUTPUT"
+
+  release:
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+    # https://github.com/softprops/action-gh-release
+    - name: Release
+      uses: softprops/action-gh-release@v2
+      with:
+        generate_release_notes: true


### PR DESCRIPTION
main 브랜치 변경 또는 버전 태그가 생성되면 이미지를 빌드하는
워크플로우 파일을 추가했습니다.

main 브랜치
- `commit-6cf931d3` 포맷의 이미지 태그

버전 태그
- `1.2.3` 포맷의 이미지 태그

