### PR TITLE
go 바이너리 빌드 이미지를 alpine으로 수정

### DIFF
--- a/build/dense-retrieval/Dockerfile
+++ b/build/dense-retrieval/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS builder
+FROM golang:1.25-alpine AS builder
 
 WORKDIR /app
 

--- a/build/lumos/Dockerfile
+++ b/build/lumos/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS builder
+FROM golang:1.25-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
멀티스테이지 빌드에서 빌드 이미지를 
크기가 더 작은 alpine 이미지로 변경했습니다.
