### PR TITLE
여러 벡터 컬렉션에서 검색하도록 개선

### DIFF
--- a/cmd/dense-retrieval/app/adapter/openai.go
+++ b/cmd/dense-retrieval/app/adapter/openai.go
@@ -29,7 +29,7 @@ func (o *OpenAIClient) Embed(ctx context.Context, text string) ([]float32, error
 		Input: openai.EmbeddingNewParamsInputUnion{
 			OfString: openai.String(text),
 		},
-		Model:          openai.EmbeddingModelTextEmbedding3Small,
+		Model:          openai.EmbeddingModelTextEmbedding3Large,
 		EncodingFormat: openai.EmbeddingNewParamsEncodingFormatFloat,
 	})
 	if err != nil {

--- a/cmd/dense-retrieval/app/adapter/qdrant.go
+++ b/cmd/dense-retrieval/app/adapter/qdrant.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"slices"
 
 	"github.com/qdrant/go-client/qdrant"
 
@@ -28,26 +29,81 @@ func NewQdrantClient(host string) (*QdrantClient, error) {
 }
 
 func (q *QdrantClient) Retrieve(ctx context.Context, params service.RetrieveParams) ([]service.RetrieveResult, error) {
-	limit := uint64(params.Limit)
-	resp, err := q.client.Query(ctx, &qdrant.QueryPoints{
-		CollectionName: "small-jira-content",
-		Query:          qdrant.NewQuery(params.Vectors...),
-		Limit:          &limit,
-		WithPayload:    qdrant.NewWithPayload(true),
-	})
-	if err != nil {
-		return nil, err
+	type passage struct {
+		Score   float32
+		Key     string
+		Title   string
+		Content string
 	}
 
-	results := make([]service.RetrieveResult, 0, len(resp))
-	for _, point := range resp {
-		data, err := json.Marshal(point.Payload)
+	var (
+		results  = make([]service.RetrieveResult, 0, params.Limit)
+		passages = make(map[string]passage, params.Limit*3)
+		limit    = uint64(params.Limit)
+	)
+
+	searchAndMerge := func(name string, limit uint64) {
+		resp, err := q.client.Query(ctx, &qdrant.QueryPoints{
+			CollectionName: name,
+			Query:          qdrant.NewQueryDense(params.Vectors),
+			Limit:          &limit,
+			WithPayload:    qdrant.NewWithPayload(true),
+		})
+
+		if err != nil {
+			slog.Warn("failed to query points", "collection", name, "error", err)
+			return
+		}
+
+		for _, point := range resp {
+			key := point.Payload["key"].GetStringValue()
+			if p, exists := passages[key]; exists {
+				p.Score = p.Score + point.Score
+				passages[key] = p
+				continue
+			}
+			title := point.Payload["title"].GetStringValue()
+			content := point.Payload["content"].GetStringValue()
+			passages[key] = passage{
+				Score:   point.Score,
+				Key:     key,
+				Title:   title,
+				Content: content,
+			}
+		}
+	}
+
+	searchAndMerge("large-jira-title", limit)
+	searchAndMerge("large-jira-content", limit)
+	searchAndMerge("large-jira-content-split", limit)
+
+	keys := make([]string, 0, len(passages))
+	for k := range passages {
+		keys = append(keys, k)
+	}
+
+	// 내림차순 정렬
+	slices.SortFunc(keys, func(a, b string) int {
+		v := passages[a].Score - passages[b].Score
+		switch {
+		case v < 0:
+			return 1
+		case v > 0:
+			return -1
+		default:
+			return 0
+		}
+	})
+
+	for _, key := range keys[:limit] {
+		value := passages[key]
+		data, err := json.Marshal(value)
 		if err != nil {
 			slog.Warn("failed to marshal payload", "error", err)
 			continue
 		}
 		results = append(results, service.RetrieveResult{
-			Score:   point.Score,
+			Score:   value.Score,
 			Passage: data,
 		})
 	}

--- a/cmd/dense-retrieval/app/adapter/qdrant.go
+++ b/cmd/dense-retrieval/app/adapter/qdrant.go
@@ -95,8 +95,8 @@ func (q *QdrantClient) Retrieve(ctx context.Context, params service.RetrievePara
 		}
 	})
 
-	for _, key := range keys[:limit] {
-		value := passages[key]
+	for i := range max(int(params.Limit), len(keys)) {
+		value := passages[keys[i]]
 		data, err := json.Marshal(value)
 		if err != nil {
 			slog.Warn("failed to marshal payload", "error", err)


### PR DESCRIPTION
dense-retireval-service 에서
`large-jira-title`, `large-jira-content`, `large-jira-content-split` 컬렉션에서
각각 검색한 다음 스코어를 더하고 정렬해 결과를 반환하도록 개선했습니다.
